### PR TITLE
:bug: Fix the blank screen issue in windows

### DIFF
--- a/bin/install_windows.ps1
+++ b/bin/install_windows.ps1
@@ -36,7 +36,7 @@ foreach ($path in $paths) {
             $pathFound = $true
             Write-Host "Installation directory: ""$(Split-Path -Path $windowHtmlPath -Parent)\copilot\"""
             Write-Host "Found Typora ""window.html"" at ""$windowHtmlPath""."
-            $content = Get-Content $windowHtmlPath -Raw
+            $content = Get-Content $windowHtmlPath -Raw -Encoding UTF8
 
             if (!($content.Contains($scriptToInsert))) {
                 Write-Host 'Installing Copilot plugin in Typora...'
@@ -55,7 +55,7 @@ foreach ($path in $paths) {
                             $(If (($rowContentBeforeScriptToInsertAfter -ne '') -and ($indent -eq '')) { '' } Else { "`n" + $indent }) +
                             $scriptToInsert
                         )
-                        Set-Content -Path $windowHtmlPath -Value $newContent
+                        Set-Content -Path $windowHtmlPath -Value $newContent -Encoding UTF8
 
                         # Copy `<cwd>\..\` to `<path_of_window_html>\copilot\` directory
                         $copilotPath = Join-Path -Path (Split-Path -Path $windowHtmlPath -Parent) -ChildPath 'copilot'

--- a/bin/uninstall_windows.ps1
+++ b/bin/uninstall_windows.ps1
@@ -35,7 +35,7 @@ foreach ($path in $paths) {
         if (Test-Path $windowHtmlPath) {
             $pathFound = $true
             Write-Host "Found Typora ""window.html"" at ""$windowHtmlPath""."
-            $content = Get-Content $windowHtmlPath -Raw
+            $content = Get-Content $windowHtmlPath -Raw -Encoding UTF8
 
             foreach ($scriptToRemoveAfter in $scriptToRemoveAfterCandidates) {
                 if ($content.Contains($scriptToRemoveAfter)) {
@@ -49,7 +49,7 @@ foreach ($path in $paths) {
 
                         # Remove script
                         $newContent = $content -replace ($indent + $scriptToRemove), ''
-                        Set-Content -Path $windowHtmlPath -Value $newContent
+                        Set-Content -Path $windowHtmlPath -Value $newContent -Encoding UTF8
 
                         # Remove `<path_of_window_html>\copilot\` directory
                         $copilotPath = Join-Path -Path (Split-Path -Path $windowHtmlPath -Parent) -ChildPath 'copilot'


### PR DESCRIPTION
Fix the blank screen issue caused by incorrect encoding (not UTF-8) when opening and saving files in Windows PowerShell script.