### PR TITLE
fix(chat): clear open flag when closing panel

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -993,6 +993,7 @@ export function attachChatPanel(): void {
     (contentDiv as HTMLElement).style.right = "0";
     contentDiv.removeEventListener("resize", updatePosition);
     window.removeEventListener("resize", updatePosition);
+    localStorage.removeItem("copilot-chat-panel-open");
     render(null, container);
     container.remove();
   };

--- a/src/footer.tsx
+++ b/src/footer.tsx
@@ -308,7 +308,6 @@ export const Footer: FC<FooterOptions> = ({ copilot }) => {
             const chatContainer = document.querySelector("#copilot-chat-container");
             if (chatContainer) {
               detachChatPanel?.();
-              localStorage.removeItem("copilot-chat-panel-open");
             } else {
               attachChatPanel();
             }


### PR DESCRIPTION
fix #28 

在关闭 chatPanel 的时候原有逻辑是在点击 footer-copilot 图标才会清理 copilot-chat-panel-open 的标记，以达到下次启动的时候能够记住是否打开的状态。

但是这样在通过右上角的关闭 btn 关闭的时候就忘了清理了。

本 PR 将清理逻辑集中到 detachChatPanel

---

感谢您的项目，在过去一段时间给了我很多帮助，另：如果能放一段开发/调试的文档会不会比较好？这样也方便大家进行参与